### PR TITLE
Reload after adding a bad formalization hint

### DIFF
--- a/src/components/badFormalizations/Checkbox.js
+++ b/src/components/badFormalizations/Checkbox.js
@@ -2,17 +2,20 @@ import React, {useEffect, useState} from 'react';
 import {Form} from 'react-bootstrap';
 import {useUpdateFeedbackMutation} from "../../redux/feedbacksSlice";
 
-export const Checkbox = ({ value, id }) => {
+export const Checkbox = ({ value, id, bad_formalization_id }) => {
     const [
         updateFeedback
     ] = useUpdateFeedbackMutation()
 
     const [isActive, setIsActive] = useState(value)
 
-    useEffect(async () => {
-        if (value !== isActive)
-            await updateFeedback({id: id, isActive: isActive})
-    }, [isActive])
+    useEffect(() => {
+        async function update() {
+            if (value !== isActive)
+                await updateFeedback({id: id, bad_formalization_id: bad_formalization_id, isActive: isActive})
+        }
+        update()
+    }, [isActive]);
 
     const handleChange = () => {
         setIsActive(!isActive);

--- a/src/components/badFormalizations/Feedbacks.js
+++ b/src/components/badFormalizations/Feedbacks.js
@@ -13,7 +13,7 @@ export const Feedbacks = ({ i, bad_formalization_id }) => {
         isSuccess,
         isError,
         error
-    } = useGetFeedbacksQuery({bad_formalization_id}, {refetchOnMountOrArgChange: true })
+    } = useGetFeedbacksQuery(bad_formalization_id)
 
     let content
 
@@ -26,7 +26,7 @@ export const Feedbacks = ({ i, bad_formalization_id }) => {
                 <ListGroup.Item as="li">
                     <div className="d-flex justify-content-between">
                         {f.author}
-                        <Checkbox id={f.feedback_id} value={f.active}/>
+                        <Checkbox id={f.feedback_id} value={f.active} bad_formalization_id={bad_formalization_id}/>
                     </div>
                     <div>{f.feedback}</div>
                     <div>shown: {f.shown}, rating: <HandThumbsUpFill/>{f.likes}, <HandThumbsDownFill/>{f.dislikes}</div>

--- a/src/redux/feedbacksSlice.js
+++ b/src/redux/feedbacksSlice.js
@@ -17,28 +17,28 @@ export const feedbacksSlice = createApi({
     tagTypes: ['Feedbacks'],
     endpoints: builder => ({
         getFeedbacks: builder.query({
-            query: (bad_formalization_id) => ({
-                url: `all/bad_formalization/${bad_formalization_id.bad_formalization_id}`,
+            query: bad_formalization_id => ({
+                url: `all/bad_formalization/${bad_formalization_id}`,
                 method: 'GET'
             }),
-            skipCache: true,
-            providesTags: ['Feedbacks'],
+            providesTags: (result, error, id) => [{ type: 'Feedbacks', id }]
+
         }),
         addFeedback: builder.mutation({
-            query: initialPost => ({
+            query: feedback => ({
                 url: '/',
                 method: 'POST',
-                body: initialPost
+                body: feedback
             }),
-            invalidatesTags: ['Feedbacks'],
+            invalidatesTags: (result, error, feedback) => [{ type: 'Feedbacks', id: feedback.bad_formalization_id }],
         }),
         updateFeedback: builder.mutation({
-            query: post => ({
-                url: `/${post.id}`,
+            query: feedback => ({
+                url: `/${feedback.id}`,
                 method: 'PATCH',
-                body: post
+                body: feedback
             }),
-            invalidatesTags: ['Feedbacks'],
+            invalidatesTags: (result, error, id) => [{ type: 'Feedbacks', id: id.bad_formalization_id }]
         })
 
     }),


### PR DESCRIPTION
When adding a new hint to a bad formalization, only its hints are re-fetched, not all bad formalization cards.
The same when we change whether a hint is active or not.

fixes #13